### PR TITLE
Gene Symbols from Ensembl or custom source + better handling of identifiers and orthology translation

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.6.0
+current_version = 1.6.1
 commit = True
 tag = True
 files = setup.py decoupler/__init__.py

--- a/decoupler/__init__.py
+++ b/decoupler/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.6.0'  # noqa: F401
+__version__ = '1.6.1'  # noqa: F401
 __version_info__ = tuple([int(num) for num in __version__.split('.')])  # noqa: F401
 
 from .pre import extract, match, rename_net, get_net_mat, filt_min_n, mask_features  # noqa: F401

--- a/decoupler/omnip.py
+++ b/decoupler/omnip.py
@@ -70,6 +70,38 @@ def _check_if_omnipath() -> ModuleType:
     return op
 
 
+def _check_if_pypath() -> None:
+
+    # Check if pypath is installed
+    try:
+
+        def ver(v):
+            return tuple(map(int, v.split('.')))
+
+        import pypath
+
+        if (
+            getattr(pypath, '__version__', None) and
+            ver(pypath.__version__) < ver(PYPATH_MIN_VERSION)
+        ):
+
+            msg = (
+                'The installed version of pypath-omnipath is too old, '
+                f'the oldest compatible version is {PYPATH_MIN_VERSION}.'
+            )
+            _misc.log_traceback(msg)
+            raise RuntimeError(msg)
+
+    except Exception:
+
+        msg = (
+            'pypath-omnipath is not installed. Please install it with: '
+            'pip install git+https://github.com/saezlab/pypath.git'
+        )
+        _misc.log_traceback(msg)
+        raise ImportError(msg)
+
+
 def _is_organism(
         name: str | int,
         organism: Literal['human', 'mouse', 'rat'],
@@ -638,37 +670,10 @@ def translate_net(
 
         return net
 
-    # Check if pypath is installed
-    try:
-
-        def ver(v):
-            return tuple(map(int, v.split('.')))
-
-        import pypath
-        from pypath.utils import orthology
-        from pypath.share import common
-        from pypath.utils import taxonomy
-
-        if (
-            getattr(pypath, '__version__', None) and
-            ver(pypath.__version__) < ver(PYPATH_MIN_VERSION)
-        ):
-
-            msg = (
-                'The installed version of pypath-omnipath is too old, '
-                f'the oldest compatible version is {PYPATH_MIN_VERSION}.'
-            )
-            _misc.log_traceback(msg)
-            raise RuntimeError(msg)
-
-    except Exception:
-
-        msg = (
-            'pypath-omnipath is not installed. Please install it with: '
-            'pip install git+https://github.com/saezlab/pypath.git'
-        )
-        _misc.log_traceback(msg)
-        raise ImportError(msg)
+    _check_if_pypath()
+    from pypath.utils import orthology
+    from pypath.share import common
+    from pypath.utils import taxonomy
 
     _source_organism = taxonomy.ensure_ncbi_tax_id(source_organism)
     _target_organism = taxonomy.ensure_ncbi_tax_id(target_organism)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="decoupler",
-    version="1.6.0",
+    version="1.6.1",
     author="Pau Badia i Mompel",
     author_email="pau.badia@uni-heidelberg.de",
     description="Ensemble of methods to infer biological activities from omics data",


### PR DESCRIPTION
Hi @PauBadiaM,

Here I implemented the stuff that the email discussion was about, now the user has 5 choices:
- Use the gene symbols from the web service (the original behaviour)
- Update them from Ensembl
- Update them from UniProt
- Provide a `dict[str, set[str]]` with any custom mapping
- Use UniProt IDs instead of gene symbols

I checked all `omnip.get_*` functions with various options, and everything looks alright for me. If you agree, feel free to merge this to `main`.