### PR TITLE
Bump python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ name = "pypi-public"
 url = "https://pypi.org/simple/"
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.12"
+python = ">=3.11"
 tqdm = "^4.66.4"
 typing-extensions = "^4.12.2"
 numba = "^0.61.0"


### PR DESCRIPTION
Is there any good reason not to support more recent versions of Python? 

According to [scientific python spec0](https://scientific-python.org/specs/spec-0000/), v3.10 is not supported anymore, and 3.11 will drop out of support in a few months. This means that numpy/scipy will not support it anymore. 

Unless there's a good reason, I would avoid specifying an upper bound for the python version. 

Close #172 